### PR TITLE
Fix layout bug in popular books table

### DIFF
--- a/src/components/PopularBooksSection.tsx
+++ b/src/components/PopularBooksSection.tsx
@@ -27,7 +27,7 @@ const BookTable = styled.div`
 
 const TableHeader = styled.div`
   display: grid;
-  grid-template-columns: 60px 1fr 120px 100px 80px 100px;
+  grid-template-columns: 60px 1fr 120px 100px 80px;
   background: var(--primary-color);
   color: white;
   padding: 16px 20px;
@@ -69,7 +69,7 @@ const HeaderCell = styled.div`
 
 const BookRow = styled.div`
   display: grid;
-  grid-template-columns: 60px 1fr 120px 100px 80px 100px;
+  grid-template-columns: 60px 1fr 120px 100px 80px;
   padding: 16px 20px;
   align-items: center;
   gap: 12px;


### PR DESCRIPTION
## Summary
- correct grid-template-columns in PopularBooksSection so header and rows line up

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a3374ace8832082b49a9efbb7c034