### PR TITLE
Add manifest.json for PWA

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,15 @@
+{
+  "short_name": "Booksori",
+  "name": "북소리",
+  "icons": [
+    {
+      "src": "/img/booksori_logo.png",
+      "type": "image/png",
+      "sizes": "512x512"
+    }
+  ],
+  "start_url": ".",
+  "display": "standalone",
+  "theme_color": "#4C8C4A",
+  "background_color": "#ffffff"
+}


### PR DESCRIPTION
## Summary
- provide a basic web app manifest so the browser won't throw manifest syntax errors

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b04b99f08832090c20d6db2a4718b